### PR TITLE
Softening the setuptools requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,15 +8,23 @@ source:
   fn: certifi-{{ version }}.tar.gz
   url: https://pypi.python.org/packages/source/c/certifi/certifi-{{ version }}.tar.gz
   sha256: 5e8eccf95924658c97b990b50552addb64f55e1e3dfe4880456ac1f287dc79d0
+  patches:
+    # Uses `distutils` if `setuptools` is not found.
+    # This will allow it to be a dependency of `setuptools`.
+    # Has already been accepted upstream, but is not yet released.
+    # The relevant PR is linked below.
+    #
+    # https://github.com/certifi/python-certifi/pull/43
+    #
+    - python-certifi_PR_43.diff
 
 build:
-  number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  number: 1
+  script: python setup.py install
 
 requirements:
   build:
     - python
-    - setuptools
   run:
     - python
 

--- a/recipe/python-certifi_PR_43.diff
+++ b/recipe/python-certifi_PR_43.diff
@@ -1,0 +1,23 @@
+diff --git setup.py setup.py
+index 030d2ad..ab6ae0b 100755
+--- setup.py
++++ setup.py
+@@ -5,7 +5,17 @@
+ import os
+ import sys
+ 
+-from setuptools import setup
++# While I generally consider it an antipattern to try and support both
++# setuptools and distutils with a single setup.py, in this specific instance
++# where certifi is a dependency of setuptools, it can create a circular
++# dependency when projects attempt to unbundle stuff from setuptools and pip.
++# Though we don't really support that, it makes things easier if we do this and
++# should hopefully cause less issues for end users.
++try:
++    from setuptools import setup
++except ImportError:
++    from distutils.core import setup
++
+ 
+ version_regex = r'__version__ = ["\']([^"\']*)["\']'
+ with open('certifi/__init__.py', 'r') as f:


### PR DESCRIPTION
I have raised this issue ( https://github.com/certifi/python-certifi/issues/42 ) upstream to allow `certifi` to be installed with `distutils` if `setuptools` is not present. Also, I proposed this PR ( https://github.com/certifi/python-certifi/pull/43 ) to do exactly that, which has been accepted (though not released). This is important as `setuptools` likes to pull in certificates when installing. Providing them to begin with could avoid some headache there. It would also give the user the same behavior they would expect in a non-conda Python environment, which seems desirable.

~~This cannot be merged yet as `setuptools` is still being installed unconditionally. Once that is changed, we can pursue this. Alternatively, we can add a workaround here if we find this to be pressing.~~ This PR includes a re-rendering with `conda-smithy` 1.0.1. So, it now uses `distutils` for the install.