### PR TITLE
Add license file

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 65ddc34fd9c8509851031d7075b8325393b87e6dbe5875a723959a20266d7a41
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ test:
 about:
   home: http://certifi.io/
   license: ISC
+  license_file: LICENSE
   summary: Python package for providing Mozilla's CA Bundle.
 
 extra:


### PR DESCRIPTION
Adds the license file to the `certifi` package as required.

Could you please merge this (if it is acceptable and passes) or incorporate it into your update PR ( https://github.com/conda-forge/certifi-feedstock/pull/12 ), @ocefpaf? Thanks.

cc @tylere