### PR TITLE
Bump to version 2016.8.31

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2016.8.8" %}
+{% set version = "2016.8.31" %}
 
 package:
   name: certifi
@@ -7,7 +7,7 @@ package:
 source:
   fn: certifi-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/c/certifi/certifi-{{ version }}.tar.gz
-  sha256: 99864ed602d8a9d212e339b15ffa438895002eda7b7db20dca5309dac9605ae9
+  sha256: f7708a42d86f29ccc7c8c4ff9d34a8d854d8d78eb2973d1f28406bb43d6b8919
 
 build:
   number: 0


### PR DESCRIPTION
This bumps `certifi` to version `2016.8.31`.