### PR TITLE
Perform Python 3.6 build using package in prerelease channel

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - CONDA_PY=27
     - CONDA_PY=34
     - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "qCl5d65ncaND6oNzBNUg+dDDrNBQVHNvx0qVykdFJX/JM+EOcua5LmxKp7ecH6CSfphS7cxn5bg1Im8MEbp+5ZE0J7q1Rs4EjBFPyy0hvU3CmCiUFw4o22684tbyBzpCZ+Aop5QYtMIe/FU16kppj9ORu/UVRkNwWnk5YgdOeXl09pep/nQ1RXcKq2BJZ+cNhl1lkJgnFVJFc0nlAlLhnMDA6S7KCUCt3Uec2yX27UaZQZwPyZAYMT7opkzPRWT4iVPtmwi9FSpOYkFV1C3Qfbl3uBJ0dEau6AK3+PvNnmeVXNI2DXQB2EF+FVSs8QonylDViM80avX18nvnG+ITiyJBOpjCDNsfnQWrmmxYvmDa8nXf2okgoLWRItR7c5rOLPvQZkd1WpFl4uJaMi1UgbS2FAZitUkM3fNGVaNLXiT8IeVN92hqG1KRJKfPilt89YlqiRg01SO1RZGLJPgnRMPyF7mqn7CDLkZ8zN1r5GmSMxiKzwlGeYLZp8Dfd1vOivZhAzdH9C/3DWAMcMGDftTbrhp9hC9hGSVhMCJhUkvW1EmiGxZux3GHGy3z8tO+xIT9ouTWIVeqB+QkwgFM2wwqYtSdIKJVddkxE/p2vwyK5cs1sql2RITc893k7uqmw5sfcTBSgB2Ycv6ztjuXIHNOPvrhyvbhydh5A3/jyfM="
@@ -32,6 +33,7 @@ install:
 
       source /Users/travis/miniconda3/bin/activate root
       conda config --add channels conda-forge
+      conda config --add channels conda-forge/label/prerelease
       conda config --set show_channel_urls true
       conda install --yes --quiet conda-forge-build-setup
       source run_conda_forge_build_setup

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Summary: Python package for providing Mozilla's CA Bundle.
 
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/certifi-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/certifi-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/certifi-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/certifi-feedstock)
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/certifi-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/certifi-feedstock/branch/master)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/certifi/badges/version.svg)](https://anaconda.org/conda-forge/certifi)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/certifi/badges/downloads.svg)](https://anaconda.org/conda-forge/certifi)
+
 Installing certifi
 ==================
 
@@ -31,7 +43,6 @@ It is possible to list all of the versions of `certifi` available on your platfo
 ```
 conda search certifi --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -67,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/certifi-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/certifi-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/certifi-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/certifi-feedstock)
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/certifi-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/certifi-feedstock/branch/master)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/certifi/badges/version.svg)](https://anaconda.org/conda-forge/certifi)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/certifi/badges/downloads.svg)](https://anaconda.org/conda-forge/certifi)
 
 
 Updating certifi-feedstock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,16 +4,11 @@
 
 environment:
 
-  CONDA_INSTALL_LOCN: "C:\\conda"
-
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script intepreter
   # See: http://stackoverflow.com/a/13751649/163740
   CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
 
-  # We set a default Python version for the miniconda that is to be installed. This can be
-  # overridden in the matrix definition where appropriate.
-  CONDA_PY: "27"
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -21,21 +16,27 @@ environment:
   matrix:
     - TARGET_ARCH: x86
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3
 
     - TARGET_ARCH: x64
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -56,24 +57,25 @@ install:
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
-    - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
-    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add our channels.
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --add channels conda-forge
 
     # Add a hack to switch to `conda` version `4.1.12` before activating.
     # This is required to handle a long path activation issue.
     # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
     - cmd: conda install --yes --quiet conda=4.1.12
     - cmd: set "PATH=%OLDPATH%"
     - cmd: set "OLDPATH="
 
+    # Actually activate `conda`.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,14 @@ environment:
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
+    - TARGET_ARCH: x86
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.
@@ -63,6 +71,7 @@ install:
     - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
     - cmd: conda config --set show_channel_urls true
     - cmd: conda config --add channels conda-forge
+    - cmd: conda config --add channels conda-forge/label/prerelease
 
     # Add a hack to switch to `conda` version `4.1.12` before activating.
     # This is required to handle a long path activation issue.

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -14,6 +14,7 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
+ - conda-forge/label/prerelease
  - defaults # As we need conda-build
 
 conda-build:
@@ -41,7 +42,7 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 3 case(s).
+# Embarking on 4 case(s).
     set -x
     export CONDA_PY=27
     set +x
@@ -56,6 +57,12 @@ source run_conda_forge_build_setup
 
     set -x
     export CONDA_PY=35
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,3 +4,7 @@ travis:
 appveyor:
   secure:
     BINSTAR_TOKEN: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
+channels:
+  sources:
+    - conda-forge
+    - conda-forge/label/prerelease


### PR DESCRIPTION
Build a Python 3.6 version of the certifi package using the python-3.6 package in the prerelease channel.