### PR TITLE
Fix autoupdates

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
     folder: boostrap_wheels
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script_env:
     # Add bootstrapped wheels to `PYTHONPATH` so Python can find them for the build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,8 @@
 {% set version = "2023.11.17" %}
 
-# Define bootstrap wheels needed to build to avoid circular dependencies
-{% set bootstrapped_wheels = [
-  {"name": "pip", "version": "23.3.2", "sha256": "5052d7889c1f9d05224cd41741acb7c5d6fa735ab34e339624a614eaaa7e7d76"},
-  {"name": "setuptools", "version": "69.0.3", "sha256": "385eb4edd9c9d5c17540511303e39a147ce2fc04bc55289c322b9e5904fe2c05"},
-  {"name": "wheel", "version": "0.42.0", "sha256": "177f9c9b0d45c47873b619f5b650346d632cdc35fb5e4d25058e09c9e581433d"},
-] %}
-
-# For conda* parsing passes, have `SRC_DIR` fallback to `"."`
-{% if SRC_DIR is undefined %}
-{% set SRC_DIR = "." %}
-{% endif %}
+{% set pip_version = "23.3.2" %}
+{% set setuptools_version = "69.0.3" %}
+{% set wheel_version = "0.42.0" %}
 
 package:
   name: certifi
@@ -21,11 +13,15 @@ source:
     sha256: 9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1
     folder: certifi
   # Download bootstrapped wheels into their respective source directories
-  {%- for w in bootstrapped_wheels %}
-  - url: https://pypi.io/packages/py3/{{ w["name"][0] }}/{{ w["name"] }}/{{ w["name"] }}-{{ w["version"] }}-py3-none-any.whl
-    sha256: {{ w["sha256"] }}
-    folder: {{ w["name"] }}_wheel
-  {%- endfor %}
+  - url: https://pypi.io/packages/py3/p/pip/pip-{{ pip_version }}-py3-none-any.whl
+    sha256: 5052d7889c1f9d05224cd41741acb7c5d6fa735ab34e339624a614eaaa7e7d76
+    folder: boostrap_wheels
+  - url: https://pypi.io/packages/py3/s/setuptools/setuptools-{{ setuptools_version }}-py3-none-any.whl
+    sha256: 385eb4edd9c9d5c17540511303e39a147ce2fc04bc55289c322b9e5904fe2c05
+    folder: boostrap_wheels
+  - url: https://pypi.io/packages/py3/w/wheel/wheel-{{ wheel_version }}-py3-none-any.whl
+    sha256: 177f9c9b0d45c47873b619f5b650346d632cdc35fb5e4d25058e09c9e581433d
+    folder: boostrap_wheels
 
 build:
   number: 1
@@ -34,10 +30,8 @@ build:
     # Add bootstrapped wheels to `PYTHONPATH` so Python can find them for the build
     - >-
       PYTHONPATH=
-      {%- for w in bootstrapped_wheels -%}
-      {{ os.sep.join([SRC_DIR, w["name"] ~ "_wheel"]) ~ os.pathsep }}
-      {%- endfor -%}
-      {{ os.environ.get("PYTHONPATH", "") }}
+      {{- os.sep.join([SRC_DIR|default("."), "boostrap_wheels"]) ~ os.pathsep }}
+      {{- os.environ.get("PYTHONPATH", "") }}
   script:
     - cd certifi
     - {{ PYTHON }} -m pip install . -vv


### PR DESCRIPTION
Looks like the autoupdate bot doesn't know how to parse the Jinja added in PR ( https://github.com/conda-forge/certifi-feedstock/pull/90 ). So instead of doing that, this puts all the bootstrap wheels in one directory and adds that to the path. This makes the handling of bootstrap wheels much simpler and hence the Jinja much simpler. Hopefully this is more to the bot's liking.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
